### PR TITLE
feat(ebird): add live recent observations client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,25 @@ recent community sightings to recommend nearby species you’ve never seen — y
 
 WingIt-MCP is written in idiomatic Go and implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io)
 to make its tools and resources discoverable to AI hosts like Claude Desktop.
+
+## Usage
+
+WingIt-MCP needs your personal checklist and a source of recent observations.
+
+### Required environment variables
+
+- `WINGIT_PERSONAL_JSON`: path to your personal eBird checklist export (JSON).
+
+### Recent observations
+
+You can run in one of two modes:
+
+- **Offline**: set `WINGIT_RECENT_JSON` to a JSON file of recent observations.
+- **Live**: set `WINGIT_EBIRD_TOKEN` to your eBird API token and pass `location` as `"lat,lon"`.
+
+Examples:
+
+- `location="42.47,-76.45"`
+- `location=" 42.47 , -76.45 "`
+
+Latitude must be between -90 and 90, and longitude between -180 and 180.

--- a/cmd/wingit-mcp/main.go
+++ b/cmd/wingit-mcp/main.go
@@ -75,7 +75,7 @@ If there are no targets, explain that there are no likely new lifers for this qu
 }
 
 func main() {
-	// IMPORTANT: stdio servers must not write to stdout; use stderr for logs. :contentReference[oaicite:1]{index=1}
+	// IMPORTANT: stdio servers must not write to stdout; use stderr for logs
 	logger := log.New(os.Stderr, "wingit-mcp: ", log.LstdFlags|log.Lmsgprefix)
 
 	// --- Config: load personal checklist path from env, build seen set ---

--- a/cmd/wingit-mcp/main.go
+++ b/cmd/wingit-mcp/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/kpb/wingit-mcp/internal/prompts"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -74,6 +76,28 @@ If there are no targets, explain that there are no likely new lifers for this qu
 	s.AddPrompt(prompt, promptHandler)
 }
 
+func parseLatLon(input string) (float64, float64, error) {
+	parts := strings.Split(strings.TrimSpace(input), ",")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("location must be \"lat,lon\" (example: \"42.47,-76.45\")")
+	}
+	lat, err := strconv.ParseFloat(strings.TrimSpace(parts[0]), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("latitude must be a number between -90 and 90 (example: \"42.47\"): %w", err)
+	}
+	lon, err := strconv.ParseFloat(strings.TrimSpace(parts[1]), 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("longitude must be a number between -180 and 180 (example: \"-76.45\"): %w", err)
+	}
+	if lat < -90 || lat > 90 {
+		return 0, 0, fmt.Errorf("latitude %v out of range; must be between -90 and 90", lat)
+	}
+	if lon < -180 || lon > 180 {
+		return 0, 0, fmt.Errorf("longitude %v out of range; must be between -180 and 180", lon)
+	}
+	return lat, lon, nil
+}
+
 func main() {
 	// IMPORTANT: stdio servers must not write to stdout; use stderr for logs
 	logger := log.New(os.Stderr, "wingit-mcp: ", log.LstdFlags|log.Lmsgprefix)
@@ -119,7 +143,19 @@ func main() {
 				recent = rows
 			}
 		} else {
-			logger.Printf("INFO: WINGIT_RECENT_JSON not set; continuing with empty recent")
+			client, err := ebird.NewClientFromEnv()
+			if err != nil {
+				return nil, nil, err
+			}
+			lat, lon, err := parseLatLon(args.Location)
+			if err != nil {
+				return nil, nil, err
+			}
+			rows, err := client.RecentNearby(ctx, lat, lon, args.RadiusKm, args.DaysBack, 0)
+			if err != nil {
+				return nil, nil, err
+			}
+			recent = rows
 		}
 
 		// Adapt internal/types -> engine's RecentObservation

--- a/cmd/wingit-mcp/main_test.go
+++ b/cmd/wingit-mcp/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import "testing"
+
+func TestParseLatLon(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantErr  bool
+		wantLat  float64
+		wantLon  float64
+	}{
+		{
+			name:    "valid",
+			input:   "42.47,-76.45",
+			wantLat: 42.47,
+			wantLon: -76.45,
+		},
+		{
+			name:    "spaces",
+			input:   " 42.47 , -76.45 ",
+			wantLat: 42.47,
+			wantLon: -76.45,
+		},
+		{
+			name:    "missing_comma",
+			input:   "42.47 -76.45",
+			wantErr: true,
+		},
+		{
+			name:    "bad_lat",
+			input:   "nope,-76.45",
+			wantErr: true,
+		},
+		{
+			name:    "bad_lon",
+			input:   "42.47,nope",
+			wantErr: true,
+		},
+		{
+			name:    "lat_out_of_range",
+			input:   "91,-76.45",
+			wantErr: true,
+		},
+		{
+			name:    "lon_out_of_range",
+			input:   "42.47,-181",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lat, lon, err := parseLatLon(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if lat != tt.wantLat || lon != tt.wantLon {
+				t.Fatalf("got lat=%v lon=%v, want lat=%v lon=%v", lat, lon, tt.wantLat, tt.wantLon)
+			}
+		})
+	}
+}

--- a/internal/ebird/client.go
+++ b/internal/ebird/client.go
@@ -76,7 +76,7 @@ func (c *Client) RecentNearby(
 		return nil, fmt.Errorf("%w: missing API token", ErrUnauthorized)
 	}
 
-	// Clamp to eBird documented ranges (engine may normalize too).
+	// Clamp to eBird documented ranges (engine may normalize too)
 	if backDays < 1 {
 		backDays = 1
 	} else if backDays > 30 {

--- a/internal/ebird/client.go
+++ b/internal/ebird/client.go
@@ -1,0 +1,150 @@
+package ebird
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kpb/wingit-mcp/internal/types"
+)
+
+const (
+	defaultBaseURL = "https://api.ebird.org"
+)
+
+var (
+	ErrUnauthorized = errors.New("ebird: unauthorized (bad token?)")
+	ErrRateLimited  = errors.New("ebird: rate limited")
+	ErrBadRequest   = errors.New("ebird: bad request")
+)
+
+type Client struct {
+	baseURL    string
+	token      string
+	httpClient *http.Client
+	userAgent  string
+}
+
+type Option func(*Client)
+
+func WithBaseURL(baseURL string) Option {
+	return func(c *Client) { c.baseURL = strings.TrimRight(baseURL, "/") }
+}
+
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) { c.httpClient = hc }
+}
+
+func WithUserAgent(ua string) Option {
+	return func(c *Client) { c.userAgent = ua }
+}
+
+func NewClient(token string, opts ...Option) *Client {
+	c := &Client{
+		baseURL: defaultBaseURL,
+		token:   strings.TrimSpace(token),
+		httpClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+		userAgent: "wingit-mcp/0.2.0 (+https://github.com/kpb/wingit-mcp)",
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// RecentNearby calls:
+// GET /v2/data/obs/geo/recent?lat=...&lng=...&dist=...&back=...&maxResults=...&sort=...
+//
+// eBird constraints: back 1-30, dist 0-50km
+func (c *Client) RecentNearby(
+	ctx context.Context,
+	lat, lng float64,
+	distKm float64,
+	backDays int,
+	maxResults int,
+) ([]types.RecentObservation, error) {
+	if c.token == "" {
+		return nil, fmt.Errorf("%w: missing API token", ErrUnauthorized)
+	}
+
+	// Clamp to eBird documented ranges (engine may normalize too).
+	if backDays < 1 {
+		backDays = 1
+	} else if backDays > 30 {
+		backDays = 30
+	}
+	if distKm < 0 {
+		distKm = 0
+	} else if distKm > 50 {
+		distKm = 50
+	}
+	if maxResults < 1 {
+		maxResults = 0 // omit
+	}
+
+	u, err := url.Parse(c.baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("ebird: invalid baseURL: %w", err)
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + "/v2/data/obs/geo/recent"
+
+	q := u.Query()
+	// Docs say “to 2 decimal places”
+	q.Set("lat", strconv.FormatFloat(lat, 'f', 2, 64))
+	q.Set("lng", strconv.FormatFloat(lng, 'f', 2, 64))
+	q.Set("dist", strconv.FormatFloat(distKm, 'f', -1, 64))
+	q.Set("back", strconv.Itoa(backDays))
+	q.Set("sort", "date") // stable default; parameterize later
+	if maxResults > 0 {
+		q.Set("maxResults", strconv.Itoa(maxResults))
+	}
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("ebird: new request: %w", err)
+	}
+	req.Header.Set("X-eBirdApiToken", c.token) // required
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("ebird: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read limited body for error messages; decode stream for success.
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+		msg := strings.TrimSpace(string(b))
+
+		switch resp.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return nil, fmt.Errorf("%w: %s", ErrUnauthorized, msg)
+		case http.StatusTooManyRequests:
+			return nil, fmt.Errorf("%w: %s", ErrRateLimited, msg)
+		case http.StatusBadRequest:
+			return nil, fmt.Errorf("%w: %s", ErrBadRequest, msg)
+		default:
+			return nil, fmt.Errorf("ebird: http %d: %s", resp.StatusCode, msg)
+		}
+	}
+
+	var out []types.RecentObservation
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(&out); err != nil {
+		return nil, fmt.Errorf("ebird: decode response: %w", err)
+	}
+	return out, nil
+}

--- a/internal/ebird/client.go
+++ b/internal/ebird/client.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/kpb/wingit-mcp/internal/types"
@@ -26,10 +28,13 @@ var (
 )
 
 type Client struct {
-	baseURL    string
-	token      string
-	httpClient *http.Client
-	userAgent  string
+	baseURL     string
+	token       string
+	httpClient  *http.Client
+	userAgent   string
+	minInterval time.Duration
+	rateMu      sync.Mutex
+	lastRequest time.Time
 }
 
 type Option func(*Client)
@@ -46,6 +51,10 @@ func WithUserAgent(ua string) Option {
 	return func(c *Client) { c.userAgent = ua }
 }
 
+func WithMinInterval(d time.Duration) Option {
+	return func(c *Client) { c.minInterval = d }
+}
+
 func NewClient(token string, opts ...Option) *Client {
 	c := &Client{
 		baseURL: defaultBaseURL,
@@ -54,11 +63,53 @@ func NewClient(token string, opts ...Option) *Client {
 			Timeout: 15 * time.Second,
 		},
 		userAgent: "wingit-mcp/0.2.0 (+https://github.com/kpb/wingit-mcp)",
+		// Simple pacing for eBird rate limits (1 request per second).
+		minInterval: time.Second,
 	}
 	for _, opt := range opts {
 		opt(c)
 	}
 	return c
+}
+
+func NewClientFromEnv(opts ...Option) (*Client, error) {
+	token := strings.TrimSpace(os.Getenv("WINGIT_EBIRD_TOKEN"))
+	if token == "" {
+		return nil, fmt.Errorf("%w: WINGIT_EBIRD_TOKEN not set", ErrUnauthorized)
+	}
+	return NewClient(token, opts...), nil
+}
+
+func (c *Client) waitForRateLimit(ctx context.Context) error {
+	if c.minInterval <= 0 {
+		return nil
+	}
+
+	c.rateMu.Lock()
+	now := time.Now()
+	next := now
+	if !c.lastRequest.IsZero() {
+		next = c.lastRequest.Add(c.minInterval)
+		if next.Before(now) {
+			next = now
+		}
+	}
+	c.lastRequest = next
+	c.rateMu.Unlock()
+
+	wait := time.Until(next)
+	if wait <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // RecentNearby calls:
@@ -74,6 +125,10 @@ func (c *Client) RecentNearby(
 ) ([]types.RecentObservation, error) {
 	if c.token == "" {
 		return nil, fmt.Errorf("%w: missing API token", ErrUnauthorized)
+	}
+
+	if err := c.waitForRateLimit(ctx); err != nil {
+		return nil, fmt.Errorf("ebird: rate limit wait: %w", err)
 	}
 
 	// Clamp to eBird documented ranges (engine may normalize too)

--- a/internal/ebird/client_test.go
+++ b/internal/ebird/client_test.go
@@ -1,0 +1,168 @@
+package ebird
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/kpb/wingit-mcp/internal/types"
+)
+
+func TestClient_RecentNearby_BuildsRequestAndDecodes(t *testing.T) {
+	t.Parallel()
+
+	const token = "test-token"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v2/data/obs/geo/recent" {
+			t.Fatalf("path = %s, want /v2/data/obs/geo/recent", r.URL.Path)
+		}
+		if got := r.Header.Get("X-eBirdApiToken"); got != token {
+			t.Fatalf("X-eBirdApiToken = %q, want %q", got, token)
+		}
+
+		q := r.URL.Query()
+		if q.Get("lat") == "" || q.Get("lng") == "" {
+			t.Fatalf("lat/lng missing: %v", q)
+		}
+		if q.Get("back") != "7" {
+			t.Fatalf("back = %q, want 7", q.Get("back"))
+		}
+		if q.Get("dist") != "20" {
+			t.Fatalf("dist = %q, want 20", q.Get("dist"))
+		}
+		if q.Get("maxResults") != "123" {
+			t.Fatalf("maxResults = %q, want 123", q.Get("maxResults"))
+		}
+
+		// Minimal sample aligned with eBird docs fields
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[
+			{
+				"speciesCode":"cangoo",
+				"comName":"Canada Goose",
+				"sciName":"Branta canadensis",
+				"locId":"L1150539",
+				"locName":"Hanshaw Rd. fields",
+				"obsDt":"2017-08-23 20:05",
+				"howMany":30,
+				"lat":42.4663513,
+				"lng":-76.4531064,
+				"obsValid":true,
+				"obsReviewed":false,
+				"locationPrivate":false
+			}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(token,
+		WithBaseURL(srv.URL),
+		WithHTTPClient(&http.Client{Timeout: 2 * time.Second}),
+	)
+
+	ctx := context.Background()
+	obs, err := c.RecentNearby(ctx, 42.47, -76.45, 20, 7, 123)
+	if err != nil {
+		t.Fatalf("RecentNearby error: %v", err)
+	}
+
+	if len(obs) != 1 {
+		t.Fatalf("len(obs)=%d, want 1", len(obs))
+	}
+
+	var _ types.RecentObservation = obs[0]
+	if obs[0].SpeciesCode != "cangoo" {
+		t.Fatalf("SpeciesCode=%q, want cangoo", obs[0].SpeciesCode)
+	}
+	if obs[0].CommonName != "Canada Goose" {
+		t.Fatalf("CommonName=%q, want Canada Goose", obs[0].CommonName)
+	}
+	if obs[0].SciName != "Branta canadensis" {
+		t.Fatalf("SciName=%q, want Branta canadensis", obs[0].SciName)
+	}
+	if obs[0].LocID != "L1150539" {
+		t.Fatalf("LocID=%q, want L1150539", obs[0].LocID)
+	}
+	if obs[0].LocName != "Hanshaw Rd. fields" {
+		t.Fatalf("LocName=%q, want Hanshaw Rd. fields", obs[0].LocName)
+	}
+	if obs[0].ObsDt != "2017-08-23 20:05" {
+		t.Fatalf("ObsDt=%q, want 2017-08-23 20:05", obs[0].ObsDt)
+	}
+
+}
+
+func TestClient_RecentNearby_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient("bad-token", WithBaseURL(srv.URL))
+	_, err := c.RecentNearby(context.Background(), 40, -105, 10, 7, 50)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if got := err.Error(); got == "" || err == nil {
+		t.Fatalf("expected non-empty error")
+	}
+}
+
+func TestClient_RecentNearby_HeardOnlyHowr(t *testing.T) {
+	t.Parallel()
+
+	const token = "test-token"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("X-eBirdApiToken"); got != token {
+			t.Fatalf("X-eBirdApiToken = %q, want %q", got, token)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		// Include howr=true (heard-only) and make sure it decodes into HeardOnly.
+		_, _ = w.Write([]byte(`[
+			{
+				"speciesCode":"amecro",
+				"comName":"American Crow",
+				"sciName":"Corvus brachyrhynchos",
+				"locName":"Somewhere Nice",
+				"locId":"L123",
+				"obsDt":"2025-12-15 08:00",
+				"howr": true
+			}
+		]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(token, WithBaseURL(srv.URL))
+
+	obs, err := c.RecentNearby(context.Background(), 40.00, -105.00, 10, 7, 25)
+	if err != nil {
+		t.Fatalf("RecentNearby error: %v", err)
+	}
+	if len(obs) != 1 {
+		t.Fatalf("len(obs)=%d, want 1", len(obs))
+	}
+
+	if obs[0].SpeciesCode != "amecro" {
+		t.Fatalf("SpeciesCode=%q, want amecro", obs[0].SpeciesCode)
+	}
+	if obs[0].CommonName != "American Crow" {
+		t.Fatalf("CommonName=%q, want American Crow", obs[0].CommonName)
+	}
+	if !obs[0].HeardOnly {
+		t.Fatalf("HeardOnly=%v, want true", obs[0].HeardOnly)
+	}
+}

--- a/internal/ebird/client_test.go
+++ b/internal/ebird/client_test.go
@@ -166,3 +166,76 @@ func TestClient_RecentNearby_HeardOnlyHowr(t *testing.T) {
 		t.Fatalf("HeardOnly=%v, want true", obs[0].HeardOnly)
 	}
 }
+
+func TestNewClientFromEnv_MissingToken(t *testing.T) {
+	t.Setenv("WINGIT_EBIRD_TOKEN", "")
+
+	_, err := NewClientFromEnv()
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestClient_RecentNearby_RateLimitPacing(t *testing.T) {
+	const token = "test-token"
+	const minInterval = 120 * time.Millisecond
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(token,
+		WithBaseURL(srv.URL),
+		WithHTTPClient(&http.Client{Timeout: 2 * time.Second}),
+		WithMinInterval(minInterval),
+	)
+
+	if _, err := c.RecentNearby(context.Background(), 40.00, -105.00, 10, 7, 25); err != nil {
+		t.Fatalf("RecentNearby error: %v", err)
+	}
+
+	start := time.Now()
+	if _, err := c.RecentNearby(context.Background(), 40.00, -105.00, 10, 7, 25); err != nil {
+		t.Fatalf("RecentNearby error: %v", err)
+	}
+
+	if elapsed := time.Since(start); elapsed < minInterval-(20*time.Millisecond) {
+		t.Fatalf("pacing too short: %v < %v", elapsed, minInterval)
+	}
+}
+
+func TestClient_RecentNearby_RateLimitRespectsContextCancel(t *testing.T) {
+	const token = "test-token"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(token,
+		WithBaseURL(srv.URL),
+		WithHTTPClient(&http.Client{Timeout: 2 * time.Second}),
+		WithMinInterval(2*time.Second),
+	)
+
+	if _, err := c.RecentNearby(context.Background(), 40.00, -105.00, 10, 7, 25); err != nil {
+		t.Fatalf("RecentNearby error: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := c.RecentNearby(ctx, 40.00, -105.00, 10, 7, 25)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 200*time.Millisecond {
+		t.Fatalf("expected quick cancel, took %v", elapsed)
+	}
+}


### PR DESCRIPTION
- add eBird HTTP client with env token support, pacing, and error handling
- wire live recent observations into the MCP tool handler
- add tests for decoding, errors, pacing, and lat/lon parsing
- document live/offline usage in README

## Testing
make test

## Notes
live mode expects location="lat,lon" and WINGIT_EBIRD_TOKEN set

Closes #1 